### PR TITLE
ci: update node version required by semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 13
+          node-version: 14
       - name: Add plugin for conventional commits
         run: npm install conventional-changelog-conventionalcommits
         working-directory: ./.github/workflows


### PR DESCRIPTION
**Description**

```
[semantic-release]: node version >=14.17 is required. Found v13.14.0.
```